### PR TITLE
feat: support custom monaco instance

### DIFF
--- a/packages/core/src/Options.ts
+++ b/packages/core/src/Options.ts
@@ -1,6 +1,7 @@
 import { SourceCache } from './SourceCache';
 import { SourceResolver } from './SourceResolver';
 import { ProgressUpdate } from './ProgressUpdate';
+import type * as monaco from 'monaco-editor';
 
 export interface Options {
   /**
@@ -137,4 +138,8 @@ export interface Options {
    * @param error a textual representation of the error.
    */
   onError?: (error: string) => void;
+  /**
+   * instance of monaco editor
+   */
+  monaco?: typeof monaco;
 }


### PR DESCRIPTION
Some package bundled a customized monaco instance, (eg. `@monaco-editor/react`).
In such case, you can only retrieve it by `useMonaco` hooks.
Thus, it need a way to paas that standalone instance into importResolver.

Also, add rootDir for tsConfig by default, it makes sure that TS-worker can load type models successfully

close #1, #3