### PR TITLE
support dynamic import syntax

### DIFF
--- a/packages/core/src/DependencyParser.ts
+++ b/packages/core/src/DependencyParser.ts
@@ -2,7 +2,7 @@ import { ImportResourcePath } from './ImportResourcePath';
 import * as path from 'path';
 export class DependencyParser {
   private REGEX_CLEAN = /[\n|\r]/g;
-  private REGEX_DETECT_IMPORT = /(?:(?:(?:import)|(?:export))(?:.)*?from\s+["']([^"']+)["'])|(?:require(?:\s+)?\(["']([^"']+)["']\))|(?:\/+\s+<reference\s+path=["']([^"']+)["']\s+\/>)/g;
+  private REGEX_DETECT_IMPORT = /(?:(?:(?:import)|(?:export))(?:.)*?from\s+["']([^"']+)["'])|(?:((?:require|import))(?:\s+)?\(["']([^"']+)["']\))|(?:\/+\s+<reference\s+path=["']([^"']+)["']\s+\/>)/g;
   private REGEX_NODE_MODULE = /^node:([\w\W\/]+)$/;
 
   public parseDependencies(source: string, parent: ImportResourcePath | string): ImportResourcePath[] {


### PR DESCRIPTION
This PR changes the regex to enable typings for [dynamic import syntax](https://dev.to/louisgv/typescript-dynamic-module-import-2dln).

Testing:
<img width="1068" alt="Screen Shot 2022-10-08 at 12 23 20 am" src="https://user-images.githubusercontent.com/34177142/194564043-8ad1026e-7b87-4fee-bfbd-57530305dcb7.png">
