### PR TITLE
Fix bug in clearing the local storage cache.

### DIFF
--- a/packages/core/src/LocalStorageCache.ts
+++ b/packages/core/src/LocalStorageCache.ts
@@ -27,7 +27,7 @@ export class LocalStorageCache implements SourceCache {
 
     for (var i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      if (key?.startsWith(TypeCache.LOCALSTORAGE_PREFIX)) {
+      if (key?.startsWith(LocalStorageCache.LOCALSTORAGE_PREFIX)) {
         foundKeys.push(key);
       }
     }

--- a/packages/core/src/LocalStorageCache.ts
+++ b/packages/core/src/LocalStorageCache.ts
@@ -23,11 +23,17 @@ export class LocalStorageCache implements SourceCache {
 
   public async clear(): Promise<void> {
     this.localCache = {};
-    for (let i = 0; i < localStorage.length; i++) {
+    const foundKeys: string[] = [];
+
+    for (var i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      if (key?.startsWith(LocalStorageCache.LOCALSTORAGE_PREFIX)) {
-        localStorage.removeItem(key);
+      if (key?.startsWith(TypeCache.LOCALSTORAGE_PREFIX)) {
+        foundKeys.push(key);
       }
+    }
+
+    for (const key of foundKeys) {
+      localStorage.removeItem(key);
     }
   }
 }


### PR DESCRIPTION
This bug appears because we are modifying the iterator while looping, while we should gather the list of keys first and then remove them.

What was happening is that not all of the cached entries were being removed.