### PR TITLE
chore(docs): update known-limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,6 @@ customize the monaco object with the `monaco` option. If you want to skip the en
 of monaco when bringing your own instance of monaco, you can import from `monaco-editor-auto-typings/custom-editor`
 instead of `monaco-editor-auto-typings`.
 
-## Known Limitations
-
-- Currently, scoped packages (`@org/...`) are not supported. This feature is blocked by
-  [this issue](https://github.com/microsoft/monaco-editor/issues/2295). `@types/...` packages
-  are not affected and work fine.
-
 ## Configuration
 
 https://lukasbach.github.io/monaco-editor-auto-typings/docs/interfaces/Options.html


### PR DESCRIPTION
Since https://github.com/microsoft/monaco-editor/issues/2295 And https://github.com/microsoft/monaco-editor/pull/3057 Has been resolved on MonacoEditor side autotyping with @scoped packages now work as expected. Updated README.md to reflect that.

Tried it out on the demo website with one of my `@` scoped package it now seems to work as intended:

<img width="1238" alt="Screenshot 2023-07-14 at 00 21 03" src="https://github.com/lukasbach/monaco-editor-auto-typings/assets/8771783/47387c0f-345d-46b8-96ea-a00abd63ce48">

Fixes #7 

@lukasbach <!-- Please leave the mention in, so that I get a notification about the PR -->
